### PR TITLE
feat: add unique id

### DIFF
--- a/src/Requests/PostEvent/JobData.php
+++ b/src/Requests/PostEvent/JobData.php
@@ -67,4 +67,9 @@ class JobData implements JsonSerializable
         }
         return $result;
     }
+
+    public function getJobId(): string
+    {
+        return $this->jobId;
+    }
 }

--- a/src/Requests/PostEvent/JobProcessingLongEventData.php
+++ b/src/Requests/PostEvent/JobProcessingLongEventData.php
@@ -42,6 +42,7 @@ class JobProcessingLongEventData implements EventDataInterface
                 'id' => $this->projectId,
                 'name' => $this->projectName,
             ],
+            'uniqueId' => $this->jobData->getJobId(),
         ];
     }
 

--- a/tests/EventsClientFunctionalTest.php
+++ b/tests/EventsClientFunctionalTest.php
@@ -9,6 +9,7 @@ use Keboola\NotificationClient\EventsClient;
 use Keboola\NotificationClient\Requests\Event;
 use Keboola\NotificationClient\Requests\PostEvent\JobData;
 use Keboola\NotificationClient\Requests\PostEvent\JobFailedEventData;
+use Keboola\NotificationClient\Requests\PostEvent\JobProcessingLongEventData;
 use PHPUnit\Framework\TestCase;
 
 class EventsClientFunctionalTest extends TestCase
@@ -29,6 +30,31 @@ class EventsClientFunctionalTest extends TestCase
                 '1234',
                 'My project',
                 'job failed',
+                new JobData(
+                    '23456',
+                    'http://someUrl',
+                    new DateTimeImmutable('2020-01-01T11:11:00+00:00'),
+                    new DateTimeImmutable('2020-01-01T12:11:00+00:00'),
+                    'keboola.orchestrator',
+                    'Orchestrator',
+                    'my-configuration',
+                    'My configuration'
+                )
+            )
+        ));
+        self::assertTrue(true);
+    }
+
+    public function testPostEventUniqueId(): void
+    {
+        $client = $this->getClient();
+        $client->postEvent(new Event(
+            new JobProcessingLongEventData(
+                '1234',
+                'My project',
+                12.5,
+                102.2,
+                120,
                 new JobData(
                     '23456',
                     'http://someUrl',

--- a/tests/EventsClientFunctionalTest.php
+++ b/tests/EventsClientFunctionalTest.php
@@ -59,7 +59,7 @@ class EventsClientFunctionalTest extends TestCase
                     '23456',
                     'http://someUrl',
                     new DateTimeImmutable('2020-01-01T11:11:00+00:00'),
-                    new DateTimeImmutable('2020-01-01T12:11:00+00:00'),
+                    null,
                     'keboola.orchestrator',
                     'Orchestrator',
                     'my-configuration',

--- a/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
@@ -49,7 +49,7 @@ class JobProcessingLongEventDataTest extends TestCase
                 'averageDuration' => 23.854,
                 'currentDuration' => 12.0,
                 'durationOvertimePercentage' => 12.534,
-                'uniqueId' => '23456'
+                'uniqueId' => '23456',
             ],
             $failedEventData->jsonSerialize()
         );

--- a/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
@@ -27,9 +27,6 @@ class JobProcessingLongEventDataTest extends TestCase
         $failedEventData = new JobProcessingLongEventData('1234', 'My project', 12.534, 23.854, 12.0, $jobData);
         self::assertSame(
             [
-                'averageDuration' => 23.854,
-                'currentDuration' => 12.0,
-                'durationOvertimePercentage' => 12.534,
                 'job' => [
                     'id' => '23456',
                     'url' => 'http://someUrl',
@@ -44,6 +41,9 @@ class JobProcessingLongEventDataTest extends TestCase
                         'id' => 'my-configuration',
                         'name' => 'My configuration',
                     ],
+                    'averageDuration' => 23.854,
+                    'currentDuration' => 12.0,
+                    'durationOvertimePercentage' => 12.534,
                 ],
                 'project' => [
                     'id' => '1234',

--- a/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
@@ -27,6 +27,9 @@ class JobProcessingLongEventDataTest extends TestCase
         $failedEventData = new JobProcessingLongEventData('1234', 'My project', 12.534, 23.854, 12.0, $jobData);
         self::assertSame(
             [
+                'averageDuration' => 23.854,
+                'currentDuration' => 12.0,
+                'durationOvertimePercentage' => 12.534,
                 'job' => [
                     'id' => '23456',
                     'url' => 'http://someUrl',
@@ -46,9 +49,6 @@ class JobProcessingLongEventDataTest extends TestCase
                     'id' => '1234',
                     'name' => 'My project',
                 ],
-                'averageDuration' => 23.854,
-                'currentDuration' => 12.0,
-                'durationOvertimePercentage' => 12.534,
                 'uniqueId' => '23456',
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
@@ -41,14 +41,15 @@ class JobProcessingLongEventDataTest extends TestCase
                         'id' => 'my-configuration',
                         'name' => 'My configuration',
                     ],
-                    'averageDuration' => 23.854,
-                    'currentDuration' => 12.0,
-                    'durationOvertimePercentage' => 12.534,
                 ],
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
                 ],
+                'averageDuration' => 23.854,
+                'currentDuration' => 12.0,
+                'durationOvertimePercentage' => 12.534,
+                'uniqueId' => '23456'
             ],
             $failedEventData->jsonSerialize()
         );

--- a/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
+++ b/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
@@ -53,7 +53,6 @@ class JobSucceededWithWarningEventDataTest extends TestCase
                     'id' => '1234',
                     'name' => 'My project',
                 ],
-                'uniqueId' => '23456',
             ],
             $failedEventData->jsonSerialize()
         );

--- a/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
+++ b/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
@@ -53,6 +53,7 @@ class JobSucceededWithWarningEventDataTest extends TestCase
                     'id' => '1234',
                     'name' => 'My project',
                 ],
+                'uniqueId' => '23456',
             ],
             $failedEventData->jsonSerialize()
         );


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2489

Tady https://github.com/keboola/notification-service/pull/76/files#diff-d86147a247388145be264bd57ef8be3a5c9aa76d45f2e1b51512dc9653fa9584R32 Pepa přidal uniqueId do notifikační služby, což zajišťje deduplikaci eventů. Event o běhu jobu se pošle pokaždé při kontrole jobu, ale notifikaci chceme pro každou subskribci poslat pro každý job jen jednou - uniqueId je teda jobId.
