### PR TITLE
SOX-328 Add `branch.id` to job events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@ COPY docker/php.ini /usr/local/etc/php/php.ini
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
-RUN pecl channel-update pecl.php.net \
-  && pecl config-set php_ini /usr/local/etc/php.ini \
-  && yes | pecl install xdebug \
-  && docker-php-ext-enable xdebug
+RUN pecl install xdebug-3.1.6 \
+ && docker-php-ext-enable xdebug
 
 COPY composer.* ./
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader

--- a/src/Requests/PostEvent/JobFailedEventData.php
+++ b/src/Requests/PostEvent/JobFailedEventData.php
@@ -10,13 +10,20 @@ class JobFailedEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private string $errorMessage;
     private JobData $jobData;
 
-    public function __construct(string $projectId, string $projectName, string $errorMessage, JobData $jobData)
-    {
+    public function __construct(
+        string $projectId,
+        string $projectName,
+        string $branchId,
+        string $errorMessage,
+        JobData $jobData
+    ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->errorMessage = $errorMessage;
         $this->jobData = $jobData;
     }
@@ -29,6 +36,9 @@ class JobFailedEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/src/Requests/PostEvent/JobProcessingLongEventData.php
+++ b/src/Requests/PostEvent/JobProcessingLongEventData.php
@@ -10,6 +10,7 @@ class JobProcessingLongEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private float $durationOvertimePercentage;
     private float $averageDuration;
     private float $currentDuration;
@@ -18,6 +19,7 @@ class JobProcessingLongEventData implements EventDataInterface
     public function __construct(
         string $projectId,
         string $projectName,
+        string $branchId,
         float $durationOvertimePercentage,
         float $averageDuration,
         float $currentDuration,
@@ -25,6 +27,7 @@ class JobProcessingLongEventData implements EventDataInterface
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->durationOvertimePercentage = $durationOvertimePercentage;
         $this->jobData = $jobData;
         $this->averageDuration = $averageDuration;
@@ -41,6 +44,9 @@ class JobProcessingLongEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
             'uniqueId' => $this->jobData->getJobId(),
         ];

--- a/src/Requests/PostEvent/JobSucceededEventData.php
+++ b/src/Requests/PostEvent/JobSucceededEventData.php
@@ -10,12 +10,18 @@ class JobSucceededEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private JobData $jobData;
 
-    public function __construct(string $projectId, string $projectName, JobData $jobData)
-    {
+    public function __construct(
+        string $projectId,
+        string $projectName,
+        string $branchId,
+        JobData $jobData
+    ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->jobData = $jobData;
     }
 
@@ -26,6 +32,9 @@ class JobSucceededEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/src/Requests/PostEvent/JobSucceededWithWarningEventData.php
+++ b/src/Requests/PostEvent/JobSucceededWithWarningEventData.php
@@ -10,13 +10,20 @@ class JobSucceededWithWarningEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private string $errorMessage;
     private JobData $jobData;
 
-    public function __construct(string $projectId, string $projectName, string $errorMessage, JobData $jobData)
-    {
+    public function __construct(
+        string $projectId,
+        string $projectName,
+        string $branchId,
+        string $errorMessage,
+        JobData $jobData
+    ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->errorMessage = $errorMessage;
         $this->jobData = $jobData;
     }
@@ -29,6 +36,9 @@ class JobSucceededWithWarningEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/src/Requests/PostEvent/PhaseJobFailedEventData.php
+++ b/src/Requests/PostEvent/PhaseJobFailedEventData.php
@@ -10,6 +10,7 @@ class PhaseJobFailedEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private string $errorMessage;
     private JobData $jobData;
     private string $phaseName;
@@ -18,6 +19,7 @@ class PhaseJobFailedEventData implements EventDataInterface
     public function __construct(
         string $projectId,
         string $projectName,
+        string $branchId,
         string $phaseName,
         string $phaseId,
         string $errorMessage,
@@ -25,6 +27,7 @@ class PhaseJobFailedEventData implements EventDataInterface
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->errorMessage = $errorMessage;
         $this->jobData = $jobData;
         $this->phaseName = $phaseName;
@@ -43,6 +46,9 @@ class PhaseJobFailedEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/src/Requests/PostEvent/PhaseJobProcessingLongEventData.php
+++ b/src/Requests/PostEvent/PhaseJobProcessingLongEventData.php
@@ -10,6 +10,7 @@ class PhaseJobProcessingLongEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private float $durationOvertimePercentage;
     private float $averageDuration;
     private float $currentDuration;
@@ -20,6 +21,7 @@ class PhaseJobProcessingLongEventData implements EventDataInterface
     public function __construct(
         string $projectId,
         string $projectName,
+        string $branchId,
         string $phaseName,
         string $phaseId,
         float $durationOvertimePercentage,
@@ -29,6 +31,7 @@ class PhaseJobProcessingLongEventData implements EventDataInterface
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->durationOvertimePercentage = $durationOvertimePercentage;
         $this->jobData = $jobData;
         $this->averageDuration = $averageDuration;
@@ -51,6 +54,9 @@ class PhaseJobProcessingLongEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
             'uniqueId' => $this->jobData->getJobId(),
         ];

--- a/src/Requests/PostEvent/PhaseJobSucceededEventData.php
+++ b/src/Requests/PostEvent/PhaseJobSucceededEventData.php
@@ -10,6 +10,7 @@ class PhaseJobSucceededEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private JobData $jobData;
     private string $phaseName;
     private string $phaseId;
@@ -17,12 +18,14 @@ class PhaseJobSucceededEventData implements EventDataInterface
     public function __construct(
         string $projectId,
         string $projectName,
+        string $branchId,
         string $phaseName,
         string $phaseId,
         JobData $jobData
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->jobData = $jobData;
         $this->phaseName = $phaseName;
         $this->phaseId = $phaseId;
@@ -39,6 +42,9 @@ class PhaseJobSucceededEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/src/Requests/PostEvent/PhaseJobSucceededWithWarningEventData.php
+++ b/src/Requests/PostEvent/PhaseJobSucceededWithWarningEventData.php
@@ -10,6 +10,7 @@ class PhaseJobSucceededWithWarningEventData implements EventDataInterface
 {
     private string $projectId;
     private string $projectName;
+    private string $branchId;
     private string $errorMessage;
     private JobData $jobData;
     private string $phaseName;
@@ -18,6 +19,7 @@ class PhaseJobSucceededWithWarningEventData implements EventDataInterface
     public function __construct(
         string $projectId,
         string $projectName,
+        string $branchId,
         string $phaseName,
         string $phaseId,
         string $errorMessage,
@@ -25,6 +27,7 @@ class PhaseJobSucceededWithWarningEventData implements EventDataInterface
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;
+        $this->branchId = $branchId;
         $this->errorMessage = $errorMessage;
         $this->jobData = $jobData;
         $this->phaseName = $phaseName;
@@ -43,6 +46,9 @@ class PhaseJobSucceededWithWarningEventData implements EventDataInterface
             'project' => [
                 'id' => $this->projectId,
                 'name' => $this->projectName,
+            ],
+            'branch' => [
+                'id' => $this->branchId,
             ],
         ];
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -116,6 +116,7 @@ class ClientTest extends TestCase
             new JobFailedEventData(
                 '1234',
                 'My project',
+                'branch-id',
                 'Some Error',
                 new JobData(
                     '23456',

--- a/tests/EventsClientFunctionalTest.php
+++ b/tests/EventsClientFunctionalTest.php
@@ -39,6 +39,7 @@ class EventsClientFunctionalTest extends TestCase
             new JobFailedEventData(
                 '1234',
                 'My project',
+                'branch-id',
                 'job failed',
                 new JobData(
                     '23456',
@@ -77,6 +78,7 @@ class EventsClientFunctionalTest extends TestCase
             new JobProcessingLongEventData(
                 '1234',
                 'My project',
+                'branch-id',
                 12.5,
                 102.2,
                 120,
@@ -118,6 +120,7 @@ class EventsClientFunctionalTest extends TestCase
             new JobFailedEventData(
                 '1234',
                 'My project',
+                'branch-id',
                 'Some Error',
                 new JobData(
                     '23456',

--- a/tests/Requests/EventTest.php
+++ b/tests/Requests/EventTest.php
@@ -18,6 +18,7 @@ class EventTest extends TestCase
             new JobFailedEventData(
                 '1234',
                 'My Project',
+                'branch-id',
                 'My failed job',
                 new JobData(
                     '23456',
@@ -52,6 +53,9 @@ class EventTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My Project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $postEventRequest->jsonSerialize()

--- a/tests/Requests/PostEvent/JobFailedEventDataTest.php
+++ b/tests/Requests/PostEvent/JobFailedEventDataTest.php
@@ -23,7 +23,13 @@ class JobFailedEventDataTest extends TestCase
             'my-configuration',
             'My configuration'
         );
-        $failedEventData = new JobFailedEventData('1234', 'My project', 'someMessage', $jobData);
+        $failedEventData = new JobFailedEventData(
+            '1234',
+            'My project',
+            'branch-id',
+            'someMessage',
+            $jobData
+        );
         self::assertSame(
             [
                 'errorMessage' => 'someMessage',
@@ -45,6 +51,9 @@ class JobFailedEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/JobProcessingLongEventDataTest.php
@@ -24,7 +24,15 @@ class JobProcessingLongEventDataTest extends TestCase
             'my-configuration',
             'My configuration'
         );
-        $failedEventData = new JobProcessingLongEventData('1234', 'My project', 12.534, 23.854, 12.0, $jobData);
+        $failedEventData = new JobProcessingLongEventData(
+            '1234',
+            'My project',
+            'branch-id',
+            12.534,
+            23.854,
+            12.0,
+            $jobData
+        );
         self::assertSame(
             [
                 'averageDuration' => 23.854,
@@ -48,6 +56,9 @@ class JobProcessingLongEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
                 'uniqueId' => '23456',
             ],

--- a/tests/Requests/PostEvent/JobSucceededEventDataTest.php
+++ b/tests/Requests/PostEvent/JobSucceededEventDataTest.php
@@ -26,6 +26,7 @@ class JobSucceededEventDataTest extends TestCase
         $failedEventData = new JobSucceededEventData(
             '1234',
             'My project',
+            'branch-id',
             $jobData
         );
 
@@ -49,6 +50,9 @@ class JobSucceededEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
+++ b/tests/Requests/PostEvent/JobSucceededWithWarningEventDataTest.php
@@ -27,6 +27,7 @@ class JobSucceededWithWarningEventDataTest extends TestCase
         $failedEventData = new JobSucceededWithWarningEventData(
             '1234',
             'My project',
+            'branch-id',
             'someMessage',
             $jobData
         );
@@ -52,6 +53,9 @@ class JobSucceededWithWarningEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/PhaseJobFailedEventDataTest.php
+++ b/tests/Requests/PostEvent/PhaseJobFailedEventDataTest.php
@@ -26,6 +26,7 @@ class PhaseJobFailedEventDataTest extends TestCase
         $failedEventData = new PhaseJobFailedEventData(
             '1234',
             'My project',
+            'branch-id',
             'Lithium Extractors',
             '123',
             'someMessage',
@@ -56,6 +57,9 @@ class PhaseJobFailedEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/PhaseJobProcessingLongEventDataTest.php
+++ b/tests/Requests/PostEvent/PhaseJobProcessingLongEventDataTest.php
@@ -26,6 +26,7 @@ class PhaseJobProcessingLongEventDataTest extends TestCase
         $failedEventData = new PhaseJobProcessingLongEventData(
             '1234',
             'My project',
+            'branch-id',
             'Lithium Extractors',
             '123',
             12.534,
@@ -60,6 +61,9 @@ class PhaseJobProcessingLongEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
                 'uniqueId' => '23456',
             ],

--- a/tests/Requests/PostEvent/PhaseJobSucceededEventDataTest.php
+++ b/tests/Requests/PostEvent/PhaseJobSucceededEventDataTest.php
@@ -26,6 +26,7 @@ class PhaseJobSucceededEventDataTest extends TestCase
         $failedEventData = new PhaseJobSucceededEventData(
             '1234',
             'My project',
+            'branch-id',
             'Lithium Extractors',
             '123',
             $jobData
@@ -55,6 +56,9 @@ class PhaseJobSucceededEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()

--- a/tests/Requests/PostEvent/PhaseJobSucceededWithWarningEventDataTest.php
+++ b/tests/Requests/PostEvent/PhaseJobSucceededWithWarningEventDataTest.php
@@ -26,6 +26,7 @@ class PhaseJobSucceededWithWarningEventDataTest extends TestCase
         $failedEventData = new PhaseJobSucceededWithWarningEventData(
             '1234',
             'My project',
+            'branch-id',
             'Lithium Extractors',
             '123',
             'someMessage',
@@ -57,6 +58,9 @@ class PhaseJobSucceededWithWarningEventDataTest extends TestCase
                 'project' => [
                     'id' => '1234',
                     'name' => 'My project',
+                ],
+                'branch' => [
+                    'id' => 'branch-id',
                 ],
             ],
             $failedEventData->jsonSerialize()


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-328
Depends on https://github.com/keboola/notification-service/pull/137

Pridani `branch.id` k Job eventum. Predpokladam teda, ze v ramci daemona uz `branchId` vzdycky zname (i kdyz je zatim technicku nullable).