### PR TITLE
feat: AJDA-381 add project webhook notification

### DIFF
--- a/src/Requests/PostNotification/ProjectWebhook.php
+++ b/src/Requests/PostNotification/ProjectWebhook.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Requests\PostNotification;
+
+use Keboola\NotificationClient\Requests\PostSubscription\WebhookRecipient;
+
+class ProjectWebhook implements NotificationInterface
+{
+    private const TYPE = 'direct-project-webhook';
+
+    private string $projectId;
+    private string $projectName;
+    private string $title;
+    private ?string $message;
+    private WebhookRecipient $recipient;
+
+    public function __construct(
+        WebhookRecipient $recipient,
+        string $projectId,
+        string $projectName,
+        string $title,
+        ?string $message
+    ) {
+        $this->recipient = $recipient;
+        $this->projectId = $projectId;
+        $this->projectName = $projectName;
+        $this->title = $title;
+        $this->message = $message;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => self::TYPE,
+            'recipient' => $this->recipient->jsonSerialize(),
+            'data' => [
+                'project' => [
+                    'id' => $this->projectId,
+                    'name' => $this->projectName,
+                ],
+                'title' => $this->title,
+                'message' => $this->message,
+            ],
+        ];
+    }
+}

--- a/tests/Requests/PostNotification/ProjectWebhookTest.php
+++ b/tests/Requests/PostNotification/ProjectWebhookTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Tests\Requests\PostNotification;
+
+use Keboola\NotificationClient\Requests\PostNotification\ProjectWebhook;
+use Keboola\NotificationClient\Requests\PostSubscription\WebhookRecipient;
+use PHPUnit\Framework\TestCase;
+
+class ProjectWebhookTest extends TestCase
+{
+    public function testJsonSerialize(): void
+    {
+        $recipient = new WebhookRecipient('https://example.com/webhook');
+        $projectId = '12345';
+        $projectName = 'Test Project';
+        $title = 'Test Notification';
+        $message = 'This is a test notification message';
+
+        $projectWebhook = new ProjectWebhook(
+            $recipient,
+            $projectId,
+            $projectName,
+            $title,
+            $message,
+        );
+
+        self::assertSame(
+            [
+                'type' => 'direct-project-webhook',
+                'recipient' => [
+                    'channel' => 'webhook',
+                    'url' => 'https://example.com/webhook',
+                ],
+                'data' => [
+                    'project' => [
+                        'id' => $projectId,
+                        'name' => $projectName,
+                    ],
+                    'title' => $title,
+                    'message' => $message,
+                ],
+            ],
+            $projectWebhook->jsonSerialize(),
+        );
+    }
+
+    public function testJsonSerializeWithNullMessage(): void
+    {
+        $recipient = new WebhookRecipient('https://example.com/webhook');
+        $projectId = '67890';
+        $projectName = 'Another Test Project';
+        $title = 'Test Notification Without Message';
+        $message = null;
+
+        $projectWebhook = new ProjectWebhook(
+            $recipient,
+            $projectId,
+            $projectName,
+            $title,
+            $message,
+        );
+
+        self::assertSame(
+            [
+                'type' => 'direct-project-webhook',
+                'recipient' => [
+                    'channel' => 'webhook',
+                    'url' => 'https://example.com/webhook',
+                ],
+                'data' => [
+                    'project' => [
+                        'id' => $projectId,
+                        'name' => $projectName,
+                    ],
+                    'title' => $title,
+                    'message' => null,
+                ],
+            ],
+            $projectWebhook->jsonSerialize(),
+        );
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/AJDA-381

Connected to https://github.com/keboola/notification-service/pull/175

- Add ProjectWebhook class for direct project webhook notifications
- Implement jsonSerialize() method with webhook recipient support
- Add comprehensive unit tests covering normal and null message scenarios