### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli
+FROM php:8.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
@@ -13,7 +13,7 @@ COPY docker/php.ini /usr/local/etc/php/php.ini
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
-RUN pecl install xdebug-3.1.6 \
+RUN pecl install xdebug \
  && docker-php-ext-enable xdebug
 
 COPY composer.* ./

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "php": "^8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.2",
-        "myclabs/php-enum": "^1.8",
         "psr/log": "^2|^3",
         "symfony/validator": "^6.4|^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "myclabs/php-enum": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "myclabs/php-enum": "^1.8",
         "psr/log": "^2|^3",
-        "symfony/validator": "^5.2|^6.0"
+        "symfony/validator": "^6.4|^7.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,13 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "myclabs/php-enum": "^1.8",
-        "psr/log": "^1.1",
+        "psr/log": "^2|^3",
         "symfony/validator": "^5.2|^6.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",
         "keboola/coding-standard": ">=14.0",
+        "monolog/monolog": "^3.9",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^9.5",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,11 @@
 parameters:
     level: max
-    checkMissingIterableValueType: false
     paths:
         - src
         - tests
     stubFiles:
         - tests/stubs/Guzzle.stub
     ignoreErrors:
-
+        - identifier: missingType.iterableValue
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/src/Client.php
+++ b/src/Client.php
@@ -42,7 +42,7 @@ abstract class Client
     public function __construct(
         string $baseUrl,
         ?string $token,
-        array $options
+        array $options,
     ) {
         $validator = Validation::createValidator();
         $errors = $validator->validate($baseUrl, [new Url()]);
@@ -79,10 +79,10 @@ abstract class Client
             $retries,
             RequestInterface $request,
             ?ResponseInterface $response = null,
-            ?Throwable $error = null
+            ?Throwable $error = null,
         ) use (
             $maxRetries,
-            $logger
+            $logger,
         ) {
             if ($retries >= $maxRetries) {
                 $logger->notice(sprintf('We have tried this %d times. Giving up.', $maxRetries));

--- a/src/Requests/PostEvent/JobData.php
+++ b/src/Requests/PostEvent/JobData.php
@@ -26,7 +26,7 @@ class JobData implements JsonSerializable
         string $componentId,
         string $componentName,
         ?string $configurationId,
-        ?string $configurationName
+        ?string $configurationName,
     ) {
         $this->jobId = $jobId;
         $this->jobUrl = $jobUrl;

--- a/src/Requests/PostEvent/JobFailedEventData.php
+++ b/src/Requests/PostEvent/JobFailedEventData.php
@@ -19,7 +19,7 @@ class JobFailedEventData implements EventDataInterface
         string $projectName,
         string $branchId,
         string $errorMessage,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/JobProcessingLongEventData.php
+++ b/src/Requests/PostEvent/JobProcessingLongEventData.php
@@ -23,7 +23,7 @@ class JobProcessingLongEventData implements EventDataInterface
         float $durationOvertimePercentage,
         float $averageDuration,
         float $currentDuration,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/JobSucceededEventData.php
+++ b/src/Requests/PostEvent/JobSucceededEventData.php
@@ -17,7 +17,7 @@ class JobSucceededEventData implements EventDataInterface
         string $projectId,
         string $projectName,
         string $branchId,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/JobSucceededWithWarningEventData.php
+++ b/src/Requests/PostEvent/JobSucceededWithWarningEventData.php
@@ -19,7 +19,7 @@ class JobSucceededWithWarningEventData implements EventDataInterface
         string $projectName,
         string $branchId,
         string $errorMessage,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/PhaseJobFailedEventData.php
+++ b/src/Requests/PostEvent/PhaseJobFailedEventData.php
@@ -23,7 +23,7 @@ class PhaseJobFailedEventData implements EventDataInterface
         string $phaseName,
         string $phaseId,
         string $errorMessage,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/PhaseJobProcessingLongEventData.php
+++ b/src/Requests/PostEvent/PhaseJobProcessingLongEventData.php
@@ -27,7 +27,7 @@ class PhaseJobProcessingLongEventData implements EventDataInterface
         float $durationOvertimePercentage,
         float $averageDuration,
         float $currentDuration,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/PhaseJobSucceededEventData.php
+++ b/src/Requests/PostEvent/PhaseJobSucceededEventData.php
@@ -21,7 +21,7 @@ class PhaseJobSucceededEventData implements EventDataInterface
         string $branchId,
         string $phaseName,
         string $phaseId,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostEvent/PhaseJobSucceededWithWarningEventData.php
+++ b/src/Requests/PostEvent/PhaseJobSucceededWithWarningEventData.php
@@ -23,7 +23,7 @@ class PhaseJobSucceededWithWarningEventData implements EventDataInterface
         string $phaseName,
         string $phaseId,
         string $errorMessage,
-        JobData $jobData
+        JobData $jobData,
     ) {
         $this->projectId = $projectId;
         $this->projectName = $projectName;

--- a/src/Requests/PostNotification/ProjectEmail.php
+++ b/src/Requests/PostNotification/ProjectEmail.php
@@ -21,7 +21,7 @@ class ProjectEmail implements NotificationInterface
         string $projectId,
         string $projectName,
         string $title,
-        string $message
+        string $message,
     ) {
         $this->recipient = $recipient;
         $this->projectId = $projectId;

--- a/src/Requests/PostNotification/ProjectWebhook.php
+++ b/src/Requests/PostNotification/ProjectWebhook.php
@@ -21,7 +21,7 @@ class ProjectWebhook implements NotificationInterface
         string $projectId,
         string $projectName,
         string $title,
-        ?string $message
+        ?string $message,
     ) {
         $this->recipient = $recipient;
         $this->projectId = $projectId;

--- a/src/Requests/PostSubscription/Filter.php
+++ b/src/Requests/PostSubscription/Filter.php
@@ -27,7 +27,7 @@ class Filter implements JsonSerializable
         ];
 
         if ($this->operator !== null) {
-            $data['operator'] = $this->operator->getValue();
+            $data['operator'] = $this->operator->value;
         }
 
         return $data;

--- a/src/Requests/PostSubscription/FilterOperator.php
+++ b/src/Requests/PostSubscription/FilterOperator.php
@@ -4,30 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\NotificationClient\Requests\PostSubscription;
 
-use DomainException;
-use MyCLabs\Enum\Enum;
-
-/**
- * @method static self EQUAL()
- * @method static self LESS_THAN()
- * @method static self GREATER_THAN()
- * @method static self LESS_THAN_OR_EQUAL()
- * @method static self GREATER_THAN_OR_EQUAL()
- *
- * @phpstan-extends Enum<string>
- */
-class FilterOperator extends Enum
+enum FilterOperator: string
 {
-    // phpcs:disable SlevomatCodingStandard.Classes.UnusedPrivateElements
-    // @phpstan-ignore-next-line
-    private const EQUAL = '=='; // can't be called EQUALS because there is a method called `equals` on base Enum class
-    // @phpstan-ignore-next-line
-    private const LESS_THAN = '<';
-    // @phpstan-ignore-next-line
-    private const GREATER_THAN = '>';
-    // @phpstan-ignore-next-line
-    private const LESS_THAN_OR_EQUAL = '<=';
-    // @phpstan-ignore-next-line
-    private const GREATER_THAN_OR_EQUAL = '>=';
-    // phpcs:enable SlevomatCodingStandard.Classes.UnusedPrivateElements
+    case Equal = '==';
+    case LessThan = '<';
+    case GreaterThan = '>';
+    case LessThanOrEqual = '<=';
+    case GreaterThanOrEqual = '>=';
 }

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -13,8 +13,9 @@ use Keboola\NotificationClient\ClientFactory;
 use Keboola\NotificationClient\EventsClient;
 use Keboola\NotificationClient\NotificationsClient;
 use Keboola\NotificationClient\SubscriptionClient;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\Test\TestLogger;
 
 class ClientFactoryTest extends TestCase
 {
@@ -55,7 +56,9 @@ class ClientFactoryTest extends TestCase
         $history = Middleware::history($requestHistory);
         $stack = HandlerStack::create($mock);
         $stack->push($history);
-        $logger = new TestLogger();
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
 
         $clientFactory = new ClientFactory(
             'https://dummy',
@@ -77,8 +80,8 @@ class ClientFactoryTest extends TestCase
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
         self::assertSame('test agent', $request->getHeader('User-Agent')[0]);
-        self::assertTrue($logger->hasDebugThatContains('"GET  /1.1" 200 '));
-        self::assertTrue($logger->hasDebugThatContains('test agent'));
+        self::assertTrue($logsHandler->hasDebugThatContains('"GET  /1.1" 200 '));
+        self::assertTrue($logsHandler->hasDebugThatContains('test agent'));
     }
 
     public function testGetClientLazy(): void
@@ -94,7 +97,9 @@ class ClientFactoryTest extends TestCase
         $history = Middleware::history($requestHistory);
         $stack = HandlerStack::create($mock);
         $stack->push($history);
-        $logger = new TestLogger();
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
 
         $clientFactory = new ClientFactory(
             'https://dummy',

--- a/tests/Requests/PostSubscription/FilterOperatorTest.php
+++ b/tests/Requests/PostSubscription/FilterOperatorTest.php
@@ -14,15 +14,15 @@ class FilterOperatorTest extends TestCase
      */
     public function testOperatorValues(FilterOperator $operator, string $expectedValue): void
     {
-        self::assertSame($expectedValue, $operator->getValue());
+        self::assertSame($expectedValue, $operator->value);
     }
 
     public function provideOperatorValues(): iterable
     {
-        yield 'equals' => [FilterOperator::EQUAL(), '=='];
-        yield 'less than' => [FilterOperator::LESS_THAN(), '<'];
-        yield 'greater than' => [FilterOperator::GREATER_THAN(), '>'];
-        yield 'less than or equals' => [FilterOperator::LESS_THAN_OR_EQUAL(), '<='];
-        yield 'greater than or equals' => [FilterOperator::GREATER_THAN_OR_EQUAL(), '>='];
+        yield 'equals' => [FilterOperator::Equal, '=='];
+        yield 'less than' => [FilterOperator::LessThan, '<'];
+        yield 'greater than' => [FilterOperator::GreaterThan, '>'];
+        yield 'less than or equals' => [FilterOperator::LessThanOrEqual, '<='];
+        yield 'greater than or equals' => [FilterOperator::GreaterThanOrEqual, '>='];
     }
 }

--- a/tests/Requests/PostSubscription/FilterTest.php
+++ b/tests/Requests/PostSubscription/FilterTest.php
@@ -24,7 +24,7 @@ class FilterTest extends TestCase
 
     public function testJsonSerializeWithOperator(): void
     {
-        $filter = new Filter('someName', 'someValue', FilterOperator::GREATER_THAN_OR_EQUAL());
+        $filter = new Filter('someName', 'someValue', FilterOperator::GreaterThanOrEqual);
         self::assertSame(
             [
                 'field' => 'someName',

--- a/tests/Requests/SubscriptionTest.php
+++ b/tests/Requests/SubscriptionTest.php
@@ -121,7 +121,7 @@ class SubscriptionTest extends TestCase
     /** @dataProvider recipientProvider */
     public function testPhaseJobSucceededWithWarningSubscription(
         RecipientInterface $recipient,
-        array $expectedRecipient
+        array $expectedRecipient,
     ): void {
         $subscriptionRequest = new Subscription(
             'phase-job-succeeded-with-warning',
@@ -225,7 +225,7 @@ class SubscriptionTest extends TestCase
     /** @dataProvider recipientProvider */
     public function testPhaseJobProcessingLongSubscription(
         RecipientInterface $recipient,
-        array $expectedRecipient
+        array $expectedRecipient,
     ): void {
         $subscriptionRequest = new Subscription(
             'phase-job-processing-long',

--- a/tests/StorageApiIndexClientTest.php
+++ b/tests/StorageApiIndexClientTest.php
@@ -11,13 +11,10 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Keboola\NotificationClient\Exception\ClientException;
-use Keboola\NotificationClient\Requests\PostSubscription\EmailRecipient;
-use Keboola\NotificationClient\Requests\PostSubscription\Filter;
-use Keboola\NotificationClient\Requests\Subscription;
 use Keboola\NotificationClient\StorageApiIndexClient;
-use Keboola\NotificationClient\SubscriptionClient;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\Test\TestLogger;
 
 class StorageApiIndexClientTest extends TestCase
 {
@@ -49,7 +46,10 @@ class StorageApiIndexClientTest extends TestCase
         $history = Middleware::history($requestHistory);
         $stack = HandlerStack::create($mock);
         $stack->push($history);
-        $logger = new TestLogger();
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('test', [$logsHandler]);
+
         $client = new StorageApiIndexClient(
             'https://dummy',
             ['handler' => $stack, 'logger' => $logger, 'backoffMaxTries' => 3, 'userAgent' => 'Test'],


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-514

Primarne jsme se potreboval zbavil `psr/log: ^1`, co se uz bije se zavislostma jinych packages. Kdyz uz jsem v tom byl, tak jsem navic
* zvednul PHP na 8.2+ (nejnizsi verze kterou jeste tak nejak plosne pouzivame)
* nahrada `myclabs/php-enum` za nativni PHP enumy (kdyz uz jsem v tom byl a stejne budu delat major release)
* zvednuti verze Symfony (povoleni 7.x)