### PR TITLE
[AJDA-2680] Add listSubscriptions() and deleteSubscription() to SubscriptionClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ foreach ($subscriptions as $subscription) {
 }
 
 // fetch a single subscription by ID
-$detail = $subscriptionClient->detailSubscription($created->getId());
+$subscription = $subscriptionClient->getSubscription($created->getId());
 
 // delete a subscription
 $subscriptionClient->deleteSubscription($created->getId());

--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ $clientFactory = new ClientFactory('https://connection.keboola.com');
 $clientFactory->getEventsClient('xxx-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
 ```
 
+### Subscription client
+
+```php
+use Keboola\NotificationClient\ClientFactory;
+use Keboola\NotificationClient\Requests\PostSubscription\EmailRecipient;
+use Keboola\NotificationClient\Requests\PostSubscription\Filter;
+use Keboola\NotificationClient\Requests\Subscription;
+
+$clientFactory = new ClientFactory('https://connection.keboola.com');
+$subscriptionClient = $clientFactory->getSubscriptionClient('xxx-storage-api-token');
+
+// create a subscription
+$created = $subscriptionClient->createSubscription(new Subscription(
+    'job-failed',
+    new EmailRecipient('you@example.com'),
+    [new Filter('project.id', '123')],
+));
+
+// list all subscriptions for the project (returned by token)
+$subscriptions = $subscriptionClient->listSubscriptions();
+foreach ($subscriptions as $subscription) {
+    echo $subscription->getId() . ': ' . $subscription->getEvent() . "\n";
+}
+
+// delete a subscription
+$subscriptionClient->deleteSubscription($created->getId());
+```
+
 ## Development
 - Create an Azure service principal to download the required images and login:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ foreach ($subscriptions as $subscription) {
     echo $subscription->getId() . ': ' . $subscription->getEvent() . "\n";
 }
 
+// fetch a single subscription by ID
+$detail = $subscriptionClient->detailSubscription($created->getId());
+
 // delete a subscription
 $subscriptionClient->deleteSubscription($created->getId());
 ```

--- a/src/SubscriptionClient.php
+++ b/src/SubscriptionClient.php
@@ -41,4 +41,30 @@ class SubscriptionClient extends Client
         }
         return new ResponseSubscription($this->sendRequest($request));
     }
+
+    public function deleteSubscription(string $id): void
+    {
+        $request = new Request(
+            'DELETE',
+            'project-subscriptions/' . rawurlencode($id),
+        );
+        $this->sendRequest($request);
+    }
+
+    /**
+     * @return array<ResponseSubscription>
+     */
+    public function listSubscriptions(): array
+    {
+        $request = new Request(
+            'GET',
+            'project-subscriptions',
+        );
+        $response = $this->sendRequest($request);
+
+        return array_values(array_map(
+            fn(array $item): ResponseSubscription => new ResponseSubscription($item),
+            $response,
+        ));
+    }
 }

--- a/src/SubscriptionClient.php
+++ b/src/SubscriptionClient.php
@@ -51,7 +51,7 @@ class SubscriptionClient extends Client
         $this->sendRequest($request);
     }
 
-    public function detailSubscription(string $id): ResponseSubscription
+    public function getSubscription(string $id): ResponseSubscription
     {
         $request = new Request(
             'GET',

--- a/src/SubscriptionClient.php
+++ b/src/SubscriptionClient.php
@@ -51,6 +51,15 @@ class SubscriptionClient extends Client
         $this->sendRequest($request);
     }
 
+    public function detailSubscription(string $id): ResponseSubscription
+    {
+        $request = new Request(
+            'GET',
+            'project-subscriptions/' . rawurlencode($id),
+        );
+        return new ResponseSubscription($this->sendRequest($request));
+    }
+
     /**
      * @return array<ResponseSubscription>
      */

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -146,7 +146,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         );
     }
 
-    public function testDetailSubscriptionHeaders(): void
+    public function testGetSubscriptionHeaders(): void
     {
         $mock = new MockHandler([
             new Response(
@@ -172,7 +172,7 @@ class SubscriptionClientFunctionalTest extends TestCase
             ['handler' => $stack, 'backoffMaxTries' => 3, 'userAgent' => 'Test'],
         );
 
-        $result = $client->detailSubscription('subscription-123');
+        $result = $client->getSubscription('subscription-123');
 
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
@@ -262,10 +262,10 @@ class SubscriptionClientFunctionalTest extends TestCase
         ));
         self::assertNotEmpty($created->getId());
 
-        // detail — must return the same subscription
-        $detail = $client->detailSubscription($created->getId());
-        self::assertSame($created->getId(), $detail->getId());
-        self::assertSame('job-failed', $detail->getEvent());
+        // get — must return the same subscription
+        $fetched = $client->getSubscription($created->getId());
+        self::assertSame($created->getId(), $fetched->getId());
+        self::assertSame('job-failed', $fetched->getEvent());
 
         // list — must contain the new subscription
         $beforeDelete = $client->listSubscriptions();

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -146,6 +146,51 @@ class SubscriptionClientFunctionalTest extends TestCase
         );
     }
 
+    public function testDetailSubscriptionHeaders(): void
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                (string) json_encode([
+                    'id' => 'subscription-123',
+                    'event' => 'job-failed',
+                    'filters' => [
+                        ['field' => 'project.id', 'value' => '123'],
+                    ],
+                    'recipient' => ['channel' => 'email', 'address' => 'a@example.com'],
+                ]),
+            ),
+        ]);
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = new SubscriptionClient(
+            'https://example.com/',
+            'testToken',
+            ['handler' => $stack, 'backoffMaxTries' => 3, 'userAgent' => 'Test'],
+        );
+
+        $result = $client->detailSubscription('subscription-123');
+
+        /** @var Request $request */
+        $request = $requestHistory[0]['request'];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://example.com/project-subscriptions/subscription-123', (string) $request->getUri());
+        self::assertSame(
+            ['User-Agent', 'X-StorageApi-Token', 'Host'],
+            array_keys($request->getHeaders()),
+        );
+
+        self::assertSame('subscription-123', $result->getId());
+        self::assertSame('job-failed', $result->getEvent());
+        self::assertSame('project.id', $result->getFilters()[0]->getField());
+        self::assertSame('123', $result->getFilters()[0]->getValue());
+        self::assertSame('email', $result->getRecipientChannel());
+        self::assertSame('a@example.com', $result->getRecipientAddress());
+    }
+
     public function testListSubscriptionsHeaders(): void
     {
         $responseBody = json_encode([
@@ -216,6 +261,11 @@ class SubscriptionClientFunctionalTest extends TestCase
             ],
         ));
         self::assertNotEmpty($created->getId());
+
+        // detail — must return the same subscription
+        $detail = $client->detailSubscription($created->getId());
+        self::assertSame($created->getId(), $detail->getId());
+        self::assertSame('job-failed', $detail->getEvent());
 
         // list — must contain the new subscription
         $beforeDelete = $client->listSubscriptions();

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -139,7 +139,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
         self::assertSame('DELETE', $request->getMethod());
-        self::assertSame('project-subscriptions/subscription-123', (string) $request->getUri());
+        self::assertSame('https://example.com/project-subscriptions/subscription-123', (string) $request->getUri());
         self::assertSame(
             ['User-Agent', 'X-StorageApi-Token', 'Host'],
             array_keys($request->getHeaders()),
@@ -183,7 +183,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         /** @var Request $request */
         $request = $requestHistory[0]['request'];
         self::assertSame('GET', $request->getMethod());
-        self::assertSame('project-subscriptions', (string) $request->getUri());
+        self::assertSame('https://example.com/project-subscriptions', (string) $request->getUri());
         self::assertSame(
             ['User-Agent', 'X-StorageApi-Token', 'Host'],
             array_keys($request->getHeaders()),

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -117,4 +117,126 @@ class SubscriptionClientFunctionalTest extends TestCase
         );
         self::assertSame(['application/json'], $request->getHeaders()['Content-type']);
     }
+
+    public function testDeleteSubscriptionHeaders(): void
+    {
+        $mock = new MockHandler([
+            new Response(204, [], ''),
+        ]);
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = new SubscriptionClient(
+            'https://example.com/',
+            'testToken',
+            ['handler' => $stack, 'backoffMaxTries' => 3, 'userAgent' => 'Test'],
+        );
+
+        $client->deleteSubscription('subscription-123');
+
+        /** @var Request $request */
+        $request = $requestHistory[0]['request'];
+        self::assertSame('DELETE', $request->getMethod());
+        self::assertSame('project-subscriptions/subscription-123', (string) $request->getUri());
+        self::assertSame(
+            ['User-Agent', 'X-StorageApi-Token', 'Host'],
+            array_keys($request->getHeaders()),
+        );
+    }
+
+    public function testListSubscriptionsHeaders(): void
+    {
+        $responseBody = json_encode([
+            [
+                'id' => 'sub-1',
+                'event' => 'job-failed',
+                'filters' => [
+                    ['field' => 'project.id', 'value' => '123'],
+                ],
+                'recipient' => ['channel' => 'email', 'address' => 'a@example.com'],
+            ],
+            [
+                'id' => 'sub-2',
+                'event' => 'job-succeeded',
+                'filters' => [],
+                'recipient' => ['channel' => 'email', 'address' => 'b@example.com'],
+            ],
+        ]);
+
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], (string) $responseBody),
+        ]);
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = new SubscriptionClient(
+            'https://example.com/',
+            'testToken',
+            ['handler' => $stack, 'backoffMaxTries' => 3, 'userAgent' => 'Test'],
+        );
+
+        $result = $client->listSubscriptions();
+
+        /** @var Request $request */
+        $request = $requestHistory[0]['request'];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('project-subscriptions', (string) $request->getUri());
+        self::assertSame(
+            ['User-Agent', 'X-StorageApi-Token', 'Host'],
+            array_keys($request->getHeaders()),
+        );
+
+        self::assertCount(2, $result);
+        self::assertContainsOnlyInstancesOf(
+            \Keboola\NotificationClient\Responses\Subscription::class,
+            $result,
+        );
+        self::assertSame('sub-1', $result[0]->getId());
+        self::assertSame('job-failed', $result[0]->getEvent());
+        self::assertSame('project.id', $result[0]->getFilters()[0]->getField());
+        self::assertSame('123', $result[0]->getFilters()[0]->getValue());
+        self::assertSame('email', $result[0]->getRecipientChannel());
+        self::assertSame('a@example.com', $result[0]->getRecipientAddress());
+        self::assertSame('sub-2', $result[1]->getId());
+    }
+
+    public function testListAndDeleteSubscriptionLifecycle(): void
+    {
+        $client = $this->getClient();
+
+        // create
+        $created = $client->createSubscription(new Subscription(
+            'job-failed',
+            new EmailRecipient('ajda-2680@example.com'),
+            [
+                new Filter('project.id', (string) getenv('TEST_STORAGE_API_PROJECT_ID')),
+            ],
+        ));
+        self::assertNotEmpty($created->getId());
+
+        // list — must contain the new subscription
+        $beforeDelete = $client->listSubscriptions();
+        self::assertContainsOnlyInstancesOf(
+            \Keboola\NotificationClient\Responses\Subscription::class,
+            $beforeDelete,
+        );
+        $ids = array_map(
+            fn(\Keboola\NotificationClient\Responses\Subscription $s): string => $s->getId(),
+            $beforeDelete,
+        );
+        self::assertContains($created->getId(), $ids);
+
+        // delete
+        $client->deleteSubscription($created->getId());
+
+        // list — must no longer contain it
+        $afterDelete = $client->listSubscriptions();
+        $idsAfter = array_map(
+            fn(\Keboola\NotificationClient\Responses\Subscription $s): string => $s->getId(),
+            $afterDelete,
+        );
+        self::assertNotContains($created->getId(), $idsAfter);
+    }
 }

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -13,6 +13,7 @@ use Keboola\NotificationClient\Exception\ClientException;
 use Keboola\NotificationClient\Requests\PostSubscription\EmailRecipient;
 use Keboola\NotificationClient\Requests\PostSubscription\Filter;
 use Keboola\NotificationClient\Requests\Subscription;
+use Keboola\NotificationClient\Responses\Subscription as ResponseSubscription;
 use Keboola\NotificationClient\StorageApiIndexClient;
 use Keboola\NotificationClient\SubscriptionClient;
 use PHPUnit\Framework\TestCase;
@@ -190,7 +191,7 @@ class SubscriptionClientFunctionalTest extends TestCase
 
         self::assertCount(2, $result);
         self::assertContainsOnlyInstancesOf(
-            \Keboola\NotificationClient\Responses\Subscription::class,
+            ResponseSubscription::class,
             $result,
         );
         self::assertSame('sub-1', $result[0]->getId());
@@ -219,11 +220,11 @@ class SubscriptionClientFunctionalTest extends TestCase
         // list — must contain the new subscription
         $beforeDelete = $client->listSubscriptions();
         self::assertContainsOnlyInstancesOf(
-            \Keboola\NotificationClient\Responses\Subscription::class,
+            ResponseSubscription::class,
             $beforeDelete,
         );
         $ids = array_map(
-            fn(\Keboola\NotificationClient\Responses\Subscription $s): string => $s->getId(),
+            fn(ResponseSubscription $s): string => $s->getId(),
             $beforeDelete,
         );
         self::assertContains($created->getId(), $ids);
@@ -234,7 +235,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         // list — must no longer contain it
         $afterDelete = $client->listSubscriptions();
         $idsAfter = array_map(
-            fn(\Keboola\NotificationClient\Responses\Subscription $s): string => $s->getId(),
+            fn(ResponseSubscription $s): string => $s->getId(),
             $afterDelete,
         );
         self::assertNotContains($created->getId(), $idsAfter);


### PR DESCRIPTION
## Summary

- Add `deleteSubscription(string $id): void` — `DELETE /project-subscriptions/{id}`
- Add `listSubscriptions(): array` returning `Responses\Subscription[]` — `GET /project-subscriptions`
- Add mock-based and live functional tests covering both methods
- Document the Subscription client usage in README

## Context

Linear: [AJDA-2680](https://linear.app/keboola/issue/AJDA-2680)

Both endpoints already exist server-side — this closes a client-side gap. Previously consumers (e.g. `flow-migration-tool`) had to subclass `SubscriptionClient` to reach them.