### PR TITLE
[AJDA-2704] Widen Filter value type to int|float|bool|string|null

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ $subscription = $subscriptionClient->getSubscription($created->getId());
 $subscriptionClient->deleteSubscription($created->getId());
 ```
 
+`Responses\Filter::getValue()` returns `int|float|bool|string|null` — the
+value type matches whatever the API returns (for example
+`durationOvertimePercentage` returns `float`).
+
 ## Development
 - Create an Azure service principal to download the required images and login:
 

--- a/src/Responses/Filter.php
+++ b/src/Responses/Filter.php
@@ -10,7 +10,7 @@ use Throwable;
 class Filter
 {
     private string $field;
-    private string $value;
+    private int|float|bool|string|null $value;
 
     public function __construct(array $data)
     {
@@ -28,7 +28,7 @@ class Filter
         return $this->field;
     }
 
-    public function getValue(): string
+    public function getValue(): int|float|bool|string|null
     {
         return $this->value;
     }

--- a/tests/Responses/FilterTest.php
+++ b/tests/Responses/FilterTest.php
@@ -17,6 +17,25 @@ class FilterTest extends TestCase
         self::assertSame('bar', $filter->getValue());
     }
 
+    /**
+     * @dataProvider provideScalarValues
+     */
+    public function testScalarValues(int|float|bool|string|null $value): void
+    {
+        $filter = new Filter(['field' => 'foo', 'value' => $value]);
+        self::assertSame('foo', $filter->getField());
+        self::assertSame($value, $filter->getValue());
+    }
+
+    public function provideScalarValues(): iterable
+    {
+        yield 'int' => [12345];
+        yield 'float' => [0.2];
+        yield 'bool true' => [true];
+        yield 'bool false' => [false];
+        yield 'null' => [null];
+    }
+
     public function testInvalidData(): void
     {
         $this->expectException(ClientException::class);


### PR DESCRIPTION
## Summary

`Responses\Filter::$value` was typed as `string`, but the upstream API ([`SubscriptionFilter::$value`](https://github.com/keboola/notification-service/blob/main/src/Entity/Subscription/SubscriptionFilter.php#L11) in `notification-service`) is `int|float|bool|string|null`. This caused `listSubscriptions()` to throw a `TypeError` on every call as soon as a non-string value (e.g. `durationOvertimePercentage = 0.2`) appeared in any filter.

## Changes

- `Filter::$value` and `Filter::getValue()` widened from `string` to `int|float|bool|string|null` to match the server-side type.
- Unit tests covering `int`, `float`, `bool` (true/false), and `null` values via data provider.

## Linear

[AJDA-2704](https://linear.app/keboola/issue/AJDA-2704/notification-api-php-client-tolerate-non-string-filter-values-in)

## Follow-up

After release, bump the constraint in `flow-migration-tool` and remove the `RawSubscriptionClient` workaround. Note: callers of `getValue()` must now handle the wider return type.