### PR TITLE
[AJDA-2706] Tolerate webhook recipients in Responses\Subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ $subscriptionClient->deleteSubscription($created->getId());
 value type matches whatever the API returns (for example
 `durationOvertimePercentage` returns `float`).
 
+### Subscription response recipients
+
+`Responses\Subscription` exposes the recipient as a polymorphic Value Object via `getRecipient(): RecipientInterface`. Two concrete types live under `Keboola\NotificationClient\Responses\Recipient`:
+
+- `EmailRecipient` — `getChannel()` returns `'email'`, `getAddress(): string`
+- `WebhookRecipient` — `getChannel()` returns `'webhook'`, `getUrl(): string`
+
+Use `instanceof` to narrow:
+
+```php
+use Keboola\NotificationClient\Responses\Recipient\EmailRecipient;
+use Keboola\NotificationClient\Responses\Recipient\WebhookRecipient;
+
+$recipient = $subscription->getRecipient();
+if ($recipient instanceof EmailRecipient) {
+    $email = $recipient->getAddress();
+} elseif ($recipient instanceof WebhookRecipient) {
+    $url = $recipient->getUrl();
+}
+```
+
+**BC change:** `Subscription::getRecipientAddress()` return type changed from `string` to `?string` and returns `null` for non-email channels. `getRecipientChannel(): string` is unchanged.
+
 ## Development
 - Create an Azure service principal to download the required images and login:
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ if ($recipient instanceof EmailRecipient) {
 }
 ```
 
-**BC change:** `Subscription::getRecipientAddress()` return type changed from `string` to `?string` and returns `null` for non-email channels. `getRecipientChannel(): string` is unchanged.
-
 ## Development
 - Create an Azure service principal to download the required images and login:
 

--- a/src/Responses/Recipient/EmailRecipient.php
+++ b/src/Responses/Recipient/EmailRecipient.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Responses\Recipient;
+
+class EmailRecipient implements RecipientInterface
+{
+    public const CHANNEL = 'email';
+
+    private string $address;
+
+    public function __construct(string $address)
+    {
+        $this->address = $address;
+    }
+
+    public function getChannel(): string
+    {
+        return self::CHANNEL;
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+}

--- a/src/Responses/Recipient/RecipientInterface.php
+++ b/src/Responses/Recipient/RecipientInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Responses\Recipient;
+
+interface RecipientInterface
+{
+    public function getChannel(): string;
+}

--- a/src/Responses/Recipient/WebhookRecipient.php
+++ b/src/Responses/Recipient/WebhookRecipient.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Responses\Recipient;
+
+class WebhookRecipient implements RecipientInterface
+{
+    public const CHANNEL = 'webhook';
+
+    private string $url;
+
+    public function __construct(string $url)
+    {
+        $this->url = $url;
+    }
+
+    public function getChannel(): string
+    {
+        return self::CHANNEL;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/Responses/Subscription.php
+++ b/src/Responses/Subscription.php
@@ -82,20 +82,4 @@ class Subscription
     {
         return $this->recipient;
     }
-
-    public function getRecipientChannel(): string
-    {
-        return $this->recipient->getChannel();
-    }
-
-    /**
-     * BC: previously `: string`. Now `: ?string`. Returns null for non-email channels (e.g. webhook).
-     */
-    public function getRecipientAddress(): ?string
-    {
-        if ($this->recipient instanceof EmailRecipient) {
-            return $this->recipient->getAddress();
-        }
-        return null;
-    }
 }

--- a/src/Responses/Subscription.php
+++ b/src/Responses/Subscription.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Keboola\NotificationClient\Responses;
 
 use Keboola\NotificationClient\Exception\ClientException;
+use Keboola\NotificationClient\Responses\Recipient\EmailRecipient;
+use Keboola\NotificationClient\Responses\Recipient\RecipientInterface;
+use Keboola\NotificationClient\Responses\Recipient\WebhookRecipient;
 use Throwable;
 
 class Subscription
@@ -13,10 +16,7 @@ class Subscription
     private string $event;
     /** @var array<Filter> */
     private array $filters;
-    /** @var string */
-    private $recipientAddress;
-    /** @var string */
-    private $recipientChannel;
+    private RecipientInterface $recipient;
 
     public function __construct(array $data)
     {
@@ -27,10 +27,30 @@ class Subscription
                 fn(array $item) => new Filter($item),
                 $data['filters'],
             ));
-            $this->recipientChannel = $data['recipient']['channel'];
-            $this->recipientAddress = $data['recipient']['address'];
+            $this->recipient = self::createRecipient($data['recipient']);
         } catch (Throwable $e) {
             throw new ClientException('Unrecognized response: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function createRecipient(array $data): RecipientInterface
+    {
+        $channel = $data['channel'];
+        assert(is_string($channel));
+        switch ($channel) {
+            case EmailRecipient::CHANNEL:
+                $address = $data['address'];
+                assert(is_string($address));
+                return new EmailRecipient($address);
+            case WebhookRecipient::CHANNEL:
+                $url = $data['url'];
+                assert(is_string($url));
+                return new WebhookRecipient($url);
+            default:
+                throw new ClientException(sprintf('Unknown recipient channel "%s"', $channel));
         }
     }
 
@@ -52,13 +72,24 @@ class Subscription
         return $this->filters;
     }
 
-    public function getRecipientAddress(): string
+    public function getRecipient(): RecipientInterface
     {
-        return $this->recipientAddress;
+        return $this->recipient;
     }
 
     public function getRecipientChannel(): string
     {
-        return $this->recipientChannel;
+        return $this->recipient->getChannel();
+    }
+
+    /**
+     * BC: previously `: string`. Now `: ?string`. Returns null for non-email channels (e.g. webhook).
+     */
+    public function getRecipientAddress(): ?string
+    {
+        if ($this->recipient instanceof EmailRecipient) {
+            return $this->recipient->getAddress();
+        }
+        return null;
     }
 }

--- a/src/Responses/Subscription.php
+++ b/src/Responses/Subscription.php
@@ -38,20 +38,26 @@ class Subscription
      */
     private static function createRecipient(array $data): RecipientInterface
     {
-        $channel = $data['channel'];
-        assert(is_string($channel));
+        $channel = self::extractString($data, 'channel');
         switch ($channel) {
             case EmailRecipient::CHANNEL:
-                $address = $data['address'];
-                assert(is_string($address));
-                return new EmailRecipient($address);
+                return new EmailRecipient(self::extractString($data, 'address'));
             case WebhookRecipient::CHANNEL:
-                $url = $data['url'];
-                assert(is_string($url));
-                return new WebhookRecipient($url);
+                return new WebhookRecipient(self::extractString($data, 'url'));
             default:
                 throw new ClientException(sprintf('Unknown recipient channel "%s"', $channel));
         }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractString(array $data, string $key): string
+    {
+        if (!array_key_exists($key, $data) || !is_string($data[$key])) {
+            throw new ClientException(sprintf('Recipient field "%s" must be a string', $key));
+        }
+        return $data[$key];
     }
 
     public function getId(): string

--- a/tests/Responses/Recipient/EmailRecipientTest.php
+++ b/tests/Responses/Recipient/EmailRecipientTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Tests\Responses\Recipient;
+
+use Keboola\NotificationClient\Responses\Recipient\EmailRecipient;
+use Keboola\NotificationClient\Responses\Recipient\RecipientInterface;
+use PHPUnit\Framework\TestCase;
+
+class EmailRecipientTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $recipient = new EmailRecipient('john.doe@example.com');
+        self::assertInstanceOf(RecipientInterface::class, $recipient);
+        self::assertSame('email', $recipient->getChannel());
+        self::assertSame('john.doe@example.com', $recipient->getAddress());
+    }
+}

--- a/tests/Responses/Recipient/WebhookRecipientTest.php
+++ b/tests/Responses/Recipient/WebhookRecipientTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\NotificationClient\Tests\Responses\Recipient;
+
+use Keboola\NotificationClient\Responses\Recipient\RecipientInterface;
+use Keboola\NotificationClient\Responses\Recipient\WebhookRecipient;
+use PHPUnit\Framework\TestCase;
+
+class WebhookRecipientTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $recipient = new WebhookRecipient('https://example.com/webhook');
+        self::assertInstanceOf(RecipientInterface::class, $recipient);
+        self::assertSame('webhook', $recipient->getChannel());
+        self::assertSame('https://example.com/webhook', $recipient->getUrl());
+    }
+}

--- a/tests/Responses/SubscriptionTest.php
+++ b/tests/Responses/SubscriptionTest.php
@@ -31,8 +31,6 @@ class SubscriptionTest extends TestCase
         $subscription = new Subscription($data);
         self::assertSame('123', $subscription->getId());
         self::assertSame('some_event', $subscription->getEvent());
-        self::assertSame('email', $subscription->getRecipientChannel());
-        self::assertSame('john.doe@example.com', $subscription->getRecipientAddress());
         self::assertCount(1, $subscription->getFilters());
         self::assertSame('bar', $subscription->getFilters()[0]->getField());
         self::assertSame('Kochba', $subscription->getFilters()[0]->getValue());
@@ -57,8 +55,6 @@ class SubscriptionTest extends TestCase
         $subscription = new Subscription($data);
         self::assertSame('29746', $subscription->getId());
         self::assertSame('job-succeeded', $subscription->getEvent());
-        self::assertSame('webhook', $subscription->getRecipientChannel());
-        self::assertNull($subscription->getRecipientAddress());
         self::assertSame([], $subscription->getFilters());
 
         $recipient = $subscription->getRecipient();

--- a/tests/Responses/SubscriptionTest.php
+++ b/tests/Responses/SubscriptionTest.php
@@ -5,19 +5,21 @@ declare(strict_types=1);
 namespace Keboola\NotificationClient\Tests\Responses;
 
 use Keboola\NotificationClient\Exception\ClientException;
+use Keboola\NotificationClient\Responses\Recipient\EmailRecipient;
+use Keboola\NotificationClient\Responses\Recipient\WebhookRecipient;
 use Keboola\NotificationClient\Responses\Subscription;
 use PHPUnit\Framework\TestCase;
 
 class SubscriptionTest extends TestCase
 {
-    public function testAccessors(): void
+    public function testEmailRecipientAccessors(): void
     {
         $data = [
             'id' => '123',
             'event' => 'some_event',
             'recipient' => [
-                'channel' => 'boo',
-                'address' => 'foo',
+                'channel' => 'email',
+                'address' => 'john.doe@example.com',
             ],
             'filters' => [
                 2 => [
@@ -28,12 +30,58 @@ class SubscriptionTest extends TestCase
         ];
         $subscription = new Subscription($data);
         self::assertSame('123', $subscription->getId());
-        self::assertSame('boo', $subscription->getRecipientChannel());
-        self::assertSame('foo', $subscription->getRecipientAddress());
         self::assertSame('some_event', $subscription->getEvent());
+        self::assertSame('email', $subscription->getRecipientChannel());
+        self::assertSame('john.doe@example.com', $subscription->getRecipientAddress());
         self::assertCount(1, $subscription->getFilters());
         self::assertSame('bar', $subscription->getFilters()[0]->getField());
         self::assertSame('Kochba', $subscription->getFilters()[0]->getValue());
+
+        $recipient = $subscription->getRecipient();
+        self::assertInstanceOf(EmailRecipient::class, $recipient);
+        self::assertSame('email', $recipient->getChannel());
+        self::assertSame('john.doe@example.com', $recipient->getAddress());
+    }
+
+    public function testWebhookRecipientAccessors(): void
+    {
+        $data = [
+            'id' => '29746',
+            'event' => 'job-succeeded',
+            'recipient' => [
+                'channel' => 'webhook',
+                'url' => 'https://asd.as',
+            ],
+            'filters' => [],
+        ];
+        $subscription = new Subscription($data);
+        self::assertSame('29746', $subscription->getId());
+        self::assertSame('job-succeeded', $subscription->getEvent());
+        self::assertSame('webhook', $subscription->getRecipientChannel());
+        self::assertNull($subscription->getRecipientAddress());
+        self::assertSame([], $subscription->getFilters());
+
+        $recipient = $subscription->getRecipient();
+        self::assertInstanceOf(WebhookRecipient::class, $recipient);
+        self::assertSame('webhook', $recipient->getChannel());
+        self::assertSame('https://asd.as', $recipient->getUrl());
+    }
+
+    public function testUnknownChannelThrows(): void
+    {
+        $data = [
+            'id' => '1',
+            'event' => 'some_event',
+            'recipient' => [
+                'channel' => 'boo',
+                'address' => 'foo',
+            ],
+            'filters' => [],
+        ];
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessageMatches('#Unrecognized response:.*?boo#');
+        $this->expectExceptionCode(0);
+        new Subscription($data);
     }
 
     public function testInvalidData(): void

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -88,7 +88,7 @@ class SubscriptionClientFunctionalTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '{"id": "1", "event": "2", "filters": [], "recipient": {"channel": "foo", "address": "bar"}}',
+                '{"id": "1", "event": "2", "filters": [], "recipient": {"channel": "email", "address": "bar"}}',
             ),
         ]);
         // Add the history middleware to the handler stack.

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -13,6 +13,7 @@ use Keboola\NotificationClient\Exception\ClientException;
 use Keboola\NotificationClient\Requests\PostSubscription\EmailRecipient;
 use Keboola\NotificationClient\Requests\PostSubscription\Filter;
 use Keboola\NotificationClient\Requests\Subscription;
+use Keboola\NotificationClient\Responses\Recipient\EmailRecipient as ResponseEmailRecipient;
 use Keboola\NotificationClient\Responses\Subscription as ResponseSubscription;
 use Keboola\NotificationClient\StorageApiIndexClient;
 use Keboola\NotificationClient\SubscriptionClient;
@@ -62,8 +63,10 @@ class SubscriptionClientFunctionalTest extends TestCase
         self::assertSame('job-failed', $response->getEvent());
         self::assertSame('project.id', $response->getFilters()[0]->getField());
         self::assertSame((string) getenv('TEST_STORAGE_API_PROJECT_ID'), $response->getFilters()[0]->getValue());
-        self::assertSame('johnDoe@example.com', $response->getRecipientAddress());
-        self::assertSame('email', $response->getRecipientChannel());
+        $recipient = $response->getRecipient();
+        self::assertInstanceOf(ResponseEmailRecipient::class, $recipient);
+        self::assertSame('email', $recipient->getChannel());
+        self::assertSame('johnDoe@example.com', $recipient->getAddress());
     }
 
     public function testCreateInvalidSubscription(): void
@@ -187,8 +190,10 @@ class SubscriptionClientFunctionalTest extends TestCase
         self::assertSame('job-failed', $result->getEvent());
         self::assertSame('project.id', $result->getFilters()[0]->getField());
         self::assertSame('123', $result->getFilters()[0]->getValue());
-        self::assertSame('email', $result->getRecipientChannel());
-        self::assertSame('a@example.com', $result->getRecipientAddress());
+        $recipient = $result->getRecipient();
+        self::assertInstanceOf(ResponseEmailRecipient::class, $recipient);
+        self::assertSame('email', $recipient->getChannel());
+        self::assertSame('a@example.com', $recipient->getAddress());
     }
 
     public function testListSubscriptionsHeaders(): void
@@ -243,8 +248,10 @@ class SubscriptionClientFunctionalTest extends TestCase
         self::assertSame('job-failed', $result[0]->getEvent());
         self::assertSame('project.id', $result[0]->getFilters()[0]->getField());
         self::assertSame('123', $result[0]->getFilters()[0]->getValue());
-        self::assertSame('email', $result[0]->getRecipientChannel());
-        self::assertSame('a@example.com', $result[0]->getRecipientAddress());
+        $recipient = $result[0]->getRecipient();
+        self::assertInstanceOf(ResponseEmailRecipient::class, $recipient);
+        self::assertSame('email', $recipient->getChannel());
+        self::assertSame('a@example.com', $recipient->getAddress());
         self::assertSame('sub-2', $result[1]->getId());
     }
 


### PR DESCRIPTION
Fixes deserialization in `Responses\Subscription`, which previously hardcoded `recipient.address` and threw `Unrecognized response: Undefined array key "address"` when a project had any webhook subscription (`recipient.url` instead of `recipient.address`).

## Changes

- New polymorphic recipient VOs under `Responses\Recipient\`:
  - `RecipientInterface` with `getChannel(): string`
  - `EmailRecipient` (channel `email`, `getAddress(): string`, `EmailRecipient::CHANNEL` constant)
  - `WebhookRecipient` (channel `webhook`, `getUrl(): string`, `WebhookRecipient::CHANNEL` constant)
- `Subscription` now branches on `recipient.channel` and instantiates the right concrete type. Unknown channels still throw `ClientException` via the existing `Unrecognized response: ...` wrapper.
- New `Subscription::getRecipient(): RecipientInterface` is the single API for recipient access.
- `Subscription::getRecipientAddress()` and `Subscription::getRecipientChannel()` removed.
- README documents the new API and the BC break.

## BC break (major)

`Subscription::getRecipientAddress()` and `Subscription::getRecipientChannel()` have been removed. Callers must migrate to `getRecipient()` and the channel-specific accessors on the recipient VO (`instanceof EmailRecipient` / `instanceof WebhookRecipient`). This requires a major version bump.

## Tests

`Tests\Responses\SubscriptionTest` covers email recipient, webhook recipient, unknown-channel error, and the existing invalid-data path. Dedicated unit tests for `EmailRecipient` and `WebhookRecipient` added. Functional tests updated to use `getRecipient()`.

## Follow-up

Unblocks AJDA-2596 (flow-migration-tool) — once released there, the loader can branch on `getRecipient()->getChannel()` (or use `instanceof`) and stop filtering webhooks out client-side.