### PR TITLE
Expose filter operator on Responses\Filter

### DIFF
--- a/src/Responses/Filter.php
+++ b/src/Responses/Filter.php
@@ -11,12 +11,14 @@ class Filter
 {
     private string $field;
     private int|float|bool|string|null $value;
+    private string $operator;
 
     public function __construct(array $data)
     {
         try {
             $this->field = $data['field'];
             $this->value = $data['value'];
+            $this->operator = $data['operator'];
             // @phpstan-ignore-next-line PHPStan is confused
         } catch (Throwable $e) {
             throw new ClientException('Unrecognized response: ' . $e->getMessage(), 0, $e);
@@ -31,5 +33,10 @@ class Filter
     public function getValue(): int|float|bool|string|null
     {
         return $this->value;
+    }
+
+    public function getOperator(): string
+    {
+        return $this->operator;
     }
 }

--- a/tests/Responses/FilterTest.php
+++ b/tests/Responses/FilterTest.php
@@ -12,9 +12,10 @@ class FilterTest extends TestCase
 {
     public function testAccessors(): void
     {
-        $filter = new Filter(['field' => 'foo', 'value' => 'bar']);
+        $filter = new Filter(['field' => 'foo', 'value' => 'bar', 'operator' => '==']);
         self::assertSame('foo', $filter->getField());
         self::assertSame('bar', $filter->getValue());
+        self::assertSame('==', $filter->getOperator());
     }
 
     /**
@@ -22,9 +23,10 @@ class FilterTest extends TestCase
      */
     public function testScalarValues(int|float|bool|string|null $value): void
     {
-        $filter = new Filter(['field' => 'foo', 'value' => $value]);
+        $filter = new Filter(['field' => 'foo', 'value' => $value, 'operator' => '==']);
         self::assertSame('foo', $filter->getField());
         self::assertSame($value, $filter->getValue());
+        self::assertSame('==', $filter->getOperator());
     }
 
     public function provideScalarValues(): iterable
@@ -36,6 +38,24 @@ class FilterTest extends TestCase
         yield 'null' => [null];
     }
 
+    /**
+     * @dataProvider provideOperators
+     */
+    public function testOperators(string $operator): void
+    {
+        $filter = new Filter(['field' => 'foo', 'value' => 'bar', 'operator' => $operator]);
+        self::assertSame($operator, $filter->getOperator());
+    }
+
+    public function provideOperators(): iterable
+    {
+        yield 'equal' => ['=='];
+        yield 'less than' => ['<'];
+        yield 'greater than' => ['>'];
+        yield 'less than or equal' => ['<='];
+        yield 'greater than or equal' => ['>='];
+    }
+
     public function testInvalidData(): void
     {
         $this->expectException(ClientException::class);
@@ -44,5 +64,13 @@ class FilterTest extends TestCase
         );
         $this->expectExceptionCode(0);
         new Filter(['boo', 'field' => 1]);
+    }
+
+    public function testMissingOperator(): void
+    {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessageMatches('#Unrecognized response:.*?operator#');
+        $this->expectExceptionCode(0);
+        new Filter(['field' => 'foo', 'value' => 'bar']);
     }
 }

--- a/tests/Responses/SubscriptionTest.php
+++ b/tests/Responses/SubscriptionTest.php
@@ -25,6 +25,7 @@ class SubscriptionTest extends TestCase
                 2 => [
                     'field' => 'bar',
                     'value' => 'Kochba',
+                    'operator' => '==',
                 ],
             ],
         ];
@@ -34,6 +35,7 @@ class SubscriptionTest extends TestCase
         self::assertCount(1, $subscription->getFilters());
         self::assertSame('bar', $subscription->getFilters()[0]->getField());
         self::assertSame('Kochba', $subscription->getFilters()[0]->getValue());
+        self::assertSame('==', $subscription->getFilters()[0]->getOperator());
 
         $recipient = $subscription->getRecipient();
         self::assertInstanceOf(EmailRecipient::class, $recipient);

--- a/tests/SubscriptionClientFunctionalTest.php
+++ b/tests/SubscriptionClientFunctionalTest.php
@@ -159,7 +159,7 @@ class SubscriptionClientFunctionalTest extends TestCase
                     'id' => 'subscription-123',
                     'event' => 'job-failed',
                     'filters' => [
-                        ['field' => 'project.id', 'value' => '123'],
+                        ['field' => 'project.id', 'value' => '123', 'operator' => '=='],
                     ],
                     'recipient' => ['channel' => 'email', 'address' => 'a@example.com'],
                 ]),
@@ -190,6 +190,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         self::assertSame('job-failed', $result->getEvent());
         self::assertSame('project.id', $result->getFilters()[0]->getField());
         self::assertSame('123', $result->getFilters()[0]->getValue());
+        self::assertSame('==', $result->getFilters()[0]->getOperator());
         $recipient = $result->getRecipient();
         self::assertInstanceOf(ResponseEmailRecipient::class, $recipient);
         self::assertSame('email', $recipient->getChannel());
@@ -203,7 +204,7 @@ class SubscriptionClientFunctionalTest extends TestCase
                 'id' => 'sub-1',
                 'event' => 'job-failed',
                 'filters' => [
-                    ['field' => 'project.id', 'value' => '123'],
+                    ['field' => 'project.id', 'value' => '123', 'operator' => '=='],
                 ],
                 'recipient' => ['channel' => 'email', 'address' => 'a@example.com'],
             ],
@@ -248,6 +249,7 @@ class SubscriptionClientFunctionalTest extends TestCase
         self::assertSame('job-failed', $result[0]->getEvent());
         self::assertSame('project.id', $result[0]->getFilters()[0]->getField());
         self::assertSame('123', $result[0]->getFilters()[0]->getValue());
+        self::assertSame('==', $result[0]->getFilters()[0]->getOperator());
         $recipient = $result[0]->getRecipient();
         self::assertInstanceOf(ResponseEmailRecipient::class, $recipient);
         self::assertSame('email', $recipient->getChannel());


### PR DESCRIPTION
## Summary

Adds the required `operator` field to `Responses\Filter` so clients can read the comparison operator that the server stored alongside the filter field and value.

The Notification API guarantees `operator` is always present in subscription filter responses — the server defaults to `==` when the field is omitted in the request — so the property is a non-nullable `string`.

## Changes

- `src/Responses/Filter.php` — new `string $operator` property assigned from `$data['operator']`, new `getOperator(): string` accessor.
- `tests/Responses/FilterTest.php` — existing test datasets updated to include `operator`, new `testOperators` data provider covering all five values (`==`, `<`, `>`, `<=`, `>=`), and a new `testMissingOperator` asserting that a payload without `operator` raises `ClientException`.
- `tests/Responses/SubscriptionTest.php` — mock data extended with `operator` plus an assertion on `getOperator()`.
- `tests/SubscriptionClientFunctionalTest.php` — `operator` added to the two response payloads and `getOperator()` asserted in both the single-subscription and list endpoints.